### PR TITLE
Fix graph viewer query parsing and layout mode switching

### DIFF
--- a/src/components/GraphViewerQueryDialog.js
+++ b/src/components/GraphViewerQueryDialog.js
@@ -41,6 +41,32 @@ const parseJson = (value) => {
 
 const stringifyEntry = (entry) => typeof entry === 'string' ? normalizeInput(entry) : JSON.stringify(entry, null, 2);
 
+const normalizeRequestEntry = (entry) => {
+  if (typeof entry === 'string') {
+    return normalizeInput(entry);
+  }
+
+  if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+    return entry;
+  }
+
+  return null;
+};
+
+export const parseGraphViewerInputs = (inputs) => inputs.flatMap((input) => {
+  const parsed = parseJson(input);
+  if (Array.isArray(parsed)) {
+    return parsed.map(normalizeRequestEntry);
+  }
+  if (parsed && Array.isArray(parsed.cypher)) {
+    return parsed.cypher.map(normalizeRequestEntry);
+  }
+  if (parsed && typeof parsed === 'object') {
+    return [parsed];
+  }
+  return [normalizeInput(input)];
+}).filter(Boolean);
+
 export default function GraphViewerQueryDialog({ open, onClose, onResult }) {
   const [inputs, setInputs] = useState([DEFAULT_QUERY]);
   const [coreNodes, setCoreNodes] = useState('ENSG00000001626');
@@ -92,16 +118,7 @@ export default function GraphViewerQueryDialog({ open, onClose, onResult }) {
     setError('');
 
     try {
-      const cypher = inputs.flatMap((input) => {
-        const parsed = parseJson(input);
-        if (Array.isArray(parsed)) {
-          return parsed;
-        }
-        if (parsed && Array.isArray(parsed.cypher)) {
-          return parsed.cypher;
-        }
-        return [normalizeInput(input)];
-      }).filter(Boolean);
+      const cypher = parseGraphViewerInputs(inputs);
       const parsedMaxNodes = Number.parseInt(maxNodes, 10);
       if (!cypher.length || !Number.isFinite(parsedMaxNodes) || parsedMaxNodes <= 0) {
         throw new Error('Provide a query and a positive max nodes value.');

--- a/src/components/GraphViewerQueryDialog.js
+++ b/src/components/GraphViewerQueryDialog.js
@@ -18,7 +18,7 @@ import {
   ToggleButtonGroup,
 } from '@mui/material';
 
-const GRAPH_VIEWER_API_URL = 'https://jieliulab3.dcmb.med.umich.edu/gkb0708/api/graph';
+export const GRAPH_VIEWER_API_URL = 'https://jieliulab3.dcmb.med.umich.edu/gkb0708/api/graph';
 const DEFAULT_QUERY = 'MATCH (n {id: "ENSG00000001626"})-[r]-(m) WITH n, r, m LIMIT 10 RETURN collect(DISTINCT n) + collect(DISTINCT m) AS nodes, collect(DISTINCT r) AS edges';
 
 const normalizeInput = (value) => String(value || '')
@@ -66,6 +66,30 @@ export const parseGraphViewerInputs = (inputs) => inputs.flatMap((input) => {
   }
   return [normalizeInput(input)];
 }).filter(Boolean);
+
+export const requestGraphViewer = async (request) => {
+  const response = await fetch(GRAPH_VIEWER_API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    throw new Error(`Graph viewer API failed with HTTP ${response.status}.`);
+  }
+
+  const payload = await response.json();
+  const graphData = payload?.combined_query_result || payload?.graph;
+  if (!graphData?.nodes || !graphData?.edges) {
+    throw new Error('Response did not contain graph nodes/edges.');
+  }
+
+  return {
+    graphData,
+    coordData: payload.xy_json || payload.coords || null,
+    metadata: payload.metadata || null,
+    request,
+  };
+};
 
 export default function GraphViewerQueryDialog({ open, onClose, onResult }) {
   const [inputs, setInputs] = useState([DEFAULT_QUERY]);
@@ -124,30 +148,13 @@ export default function GraphViewerQueryDialog({ open, onClose, onResult }) {
         throw new Error('Provide a query and a positive max nodes value.');
       }
 
-      const response = await fetch(GRAPH_VIEWER_API_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          cypher,
-          core_nodes: coreNodes.split(/[\s,]+/).filter(Boolean),
-          max_nodes: parsedMaxNodes,
-          layout_mode: layoutMode,
-        }),
-      });
-      if (!response.ok) {
-        throw new Error(`Graph viewer API failed with HTTP ${response.status}.`);
-      }
-
-      const payload = await response.json();
-      const graphData = payload?.combined_query_result || payload?.graph;
-      if (!graphData?.nodes || !graphData?.edges) {
-        throw new Error('Response did not contain graph nodes/edges.');
-      }
-      onResult({
-        graphData,
-        coordData: payload.xy_json || payload.coords || null,
-        metadata: payload.metadata || null,
-      });
+      const request = {
+        cypher,
+        core_nodes: coreNodes.split(/[\s,]+/).filter(Boolean),
+        max_nodes: parsedMaxNodes,
+        layout_mode: layoutMode,
+      };
+      onResult(await requestGraphViewer(request));
       onClose();
     } catch (submitError) {
       setError(submitError.message || 'Graph viewer request failed.');

--- a/src/components/GraphViewerQueryDialog.test.js
+++ b/src/components/GraphViewerQueryDialog.test.js
@@ -1,0 +1,35 @@
+import { parseGraphViewerInputs } from './GraphViewerQueryDialog';
+
+describe('parseGraphViewerInputs', () => {
+  test('preserves a standalone PostgreSQL request object', () => {
+    const request = {
+      source: 'pgsql',
+      api: 'chr/features/by-node',
+      searched_id: 'ENSG00000001626',
+      relative_position: 'downstream',
+      feature_types: ['Gene'],
+      limit: 1,
+    };
+
+    expect(parseGraphViewerInputs([JSON.stringify(request)])).toEqual([request]);
+  });
+
+  test('preserves mixed Neo4j and PostgreSQL entries from a request list', () => {
+    const cypher = 'MATCH (g:Gene {id: "ENSG00000001626"}) RETURN collect(g) AS nodes, [] AS edges';
+    const pgsql = {
+      source: 'pgsql',
+      api: 'chr/features/by-node',
+      searched_id: 'ENSG00000001626',
+      relative_position: 'downstream',
+      feature_types: ['Gene'],
+      limit: 1,
+    };
+
+    const parsed = parseGraphViewerInputs([JSON.stringify([cypher, pgsql])]);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toContain('MATCH (g:Gene {id: "ENSG00000001626"})');
+    expect(parsed[0]).toContain('RETURN collect(g) AS nodes, [] AS edges');
+    expect(parsed[1]).toEqual(pgsql);
+  });
+});

--- a/src/components/StandaloneKnowledgeGraph.js
+++ b/src/components/StandaloneKnowledgeGraph.js
@@ -321,46 +321,31 @@ const getRenderHeight = (posData) => {
   return Number.isFinite(posData?.height) ? scaleHeight(posData.height) : posData?.height;
 };
 
-const getCoordinateCenterY = (posData) => {
-  if (Number.isFinite(posData?.y)) {
-    return posData.y;
-  }
+export const getGenomeLaneModelYs = (genomeRegion, genomeTracks) => {
+  const groups = Array.isArray(genomeRegion?.groups) && genomeRegion.groups.length
+    ? genomeRegion.groups
+    : (Array.isArray(genomeTracks?.groups) ? genomeTracks.groups : []);
+  const groupedLanes = groups.flatMap((group, groupIndex) => (
+    Array.isArray(group?.lanes)
+      ? group.lanes.map((lane) => ({
+        ...lane,
+        groupKey: `${group.genome_assembly || ''}:${group.chr || ''}:${groupIndex}`,
+      }))
+      : []
+  ));
+  const lanes = groupedLanes.length
+    ? groupedLanes
+    : (Array.isArray(genomeRegion?.lanes) && genomeRegion.lanes.length
+      ? genomeRegion.lanes
+      : (Array.isArray(genomeTracks?.lanes) ? genomeTracks.lanes : []));
 
-  const boxCorners = getBoxCorners(posData);
-  return boxCorners ? (boxCorners.startY + boxCorners.endY) / 2 : null;
-};
-
-export const getGenomeLaneModelYs = (genomeRegion, genomeTracks, graphData, coordData) => {
-  const lanes = Array.isArray(genomeRegion?.lanes) ? genomeRegion.lanes : [];
-  if (!lanes.length) {
-    return [];
-  }
-
-  const laneByName = new Map(lanes.map((lane) => [lane.name, lane]));
-  const laneYs = lanes.map((lane) => lane.y).filter(Number.isFinite);
-  const minY = Number.isFinite(genomeTracks?.min_y) ? genomeTracks.min_y : Math.min(...laneYs);
-  const maxY = Number.isFinite(genomeTracks?.max_y) ? genomeTracks.max_y : Math.max(...laneYs);
-  let normalError = 0;
-  let invertedError = 0;
-  let anchorCount = 0;
-
-  (graphData?.nodes || []).forEach((node) => {
-    const lane = (node?.['~labels'] || []).map((label) => laneByName.get(label)).find(Boolean);
-    const coordinateY = getCoordinateCenterY(coordData?.[node?.['~id']]);
-    if (!lane || !Number.isFinite(coordinateY)) {
-      return;
-    }
-
-    normalError += Math.abs(coordinateY - lane.y);
-    invertedError += Math.abs(coordinateY - (minY + maxY - lane.y));
-    anchorCount += 1;
-  });
-
-  const inverted = anchorCount > 0 && invertedError < normalError;
-  return lanes.map((lane) => ({
-    ...lane,
-    modelY: inverted ? minY + maxY - lane.y : lane.y,
-  }));
+  return lanes
+    .filter((lane) => lane?.name && Number.isFinite(lane.y))
+    .map((lane, laneIndex) => ({
+      ...lane,
+      key: `${lane.groupKey || 'default'}:${lane.name}:${laneIndex}`,
+      modelY: lane.y,
+    }));
 };
 
 const getLabelMaxWidth = (renderWidth) => {
@@ -668,10 +653,9 @@ export default function StandaloneKnowledgeGraph({
     const lanes = getGenomeLaneModelYs(
       genomeRegion,
       effectiveMetadata?.layout?.genome_tracks,
-      displayGraphData,
-      displayCoordData,
     );
     const laneLabels = lanes.map((lane) => ({
+      key: lane.key,
       name: lane.name,
       centerY: scaleYPosition(lane.modelY) * zoom + panY,
     }));
@@ -1201,7 +1185,7 @@ export default function StandaloneKnowledgeGraph({
         >
           {trackOverlay.laneLabels.map((lane) => (
             <div
-              key={lane.name}
+              key={lane.key}
               style={{
                 position: 'absolute',
                 left: '226px',

--- a/src/components/StandaloneKnowledgeGraph.js
+++ b/src/components/StandaloneKnowledgeGraph.js
@@ -322,28 +322,28 @@ const getRenderHeight = (posData) => {
 };
 
 export const getGenomeLaneModelYs = (genomeRegion, genomeTracks) => {
-  const groups = Array.isArray(genomeRegion?.groups) && genomeRegion.groups.length
+  const regionLanes = Array.isArray(genomeRegion?.lanes) ? genomeRegion.lanes : [];
+  const trackLanes = Array.isArray(genomeTracks?.lanes) ? genomeTracks.lanes : [];
+  const fallbackGroups = Array.isArray(genomeRegion?.groups) && genomeRegion.groups.length
     ? genomeRegion.groups
     : (Array.isArray(genomeTracks?.groups) ? genomeTracks.groups : []);
-  const groupedLanes = groups.flatMap((group, groupIndex) => (
-    Array.isArray(group?.lanes)
-      ? group.lanes.map((lane) => ({
-        ...lane,
-        groupKey: `${group.genome_assembly || ''}:${group.chr || ''}:${groupIndex}`,
-      }))
-      : []
-  ));
-  const lanes = groupedLanes.length
-    ? groupedLanes
-    : (Array.isArray(genomeRegion?.lanes) && genomeRegion.lanes.length
-      ? genomeRegion.lanes
-      : (Array.isArray(genomeTracks?.lanes) ? genomeTracks.lanes : []));
+  const fallbackLanesByName = new Map();
+  fallbackGroups.forEach((group) => {
+    (Array.isArray(group?.lanes) ? group.lanes : []).forEach((lane) => {
+      if (!fallbackLanesByName.has(lane?.name)) {
+        fallbackLanesByName.set(lane?.name, lane);
+      }
+    });
+  });
+  const lanes = regionLanes.length
+    ? regionLanes
+    : (trackLanes.length ? trackLanes : Array.from(fallbackLanesByName.values()));
 
   return lanes
     .filter((lane) => lane?.name && Number.isFinite(lane.y))
     .map((lane, laneIndex) => ({
       ...lane,
-      key: `${lane.groupKey || 'default'}:${lane.name}:${laneIndex}`,
+      key: `${lane.name}:${laneIndex}`,
       modelY: lane.y,
     }));
 };

--- a/src/components/StandaloneKnowledgeGraph.js
+++ b/src/components/StandaloneKnowledgeGraph.js
@@ -14,6 +14,7 @@ import { useSelector } from 'react-redux';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import {
+  Alert,
   Box,
   Button,
   Link,
@@ -27,7 +28,7 @@ import downloadIcon from '../image/material-symbols--download-rounded.svg';
 import recenterIcon from '../image/material-symbols--recenter-rounded.svg';
 import graphInfocard from '../schema/graph_viewer_schema.json';
 import { addWhitespace } from '../utils/textProcessing';
-import GraphViewerQueryDialog from './GraphViewerQueryDialog';
+import GraphViewerQueryDialog, { requestGraphViewer } from './GraphViewerQueryDialog';
 import {
   edgeIsInverted,
   edgeLabels,
@@ -320,6 +321,48 @@ const getRenderHeight = (posData) => {
   return Number.isFinite(posData?.height) ? scaleHeight(posData.height) : posData?.height;
 };
 
+const getCoordinateCenterY = (posData) => {
+  if (Number.isFinite(posData?.y)) {
+    return posData.y;
+  }
+
+  const boxCorners = getBoxCorners(posData);
+  return boxCorners ? (boxCorners.startY + boxCorners.endY) / 2 : null;
+};
+
+export const getGenomeLaneModelYs = (genomeRegion, genomeTracks, graphData, coordData) => {
+  const lanes = Array.isArray(genomeRegion?.lanes) ? genomeRegion.lanes : [];
+  if (!lanes.length) {
+    return [];
+  }
+
+  const laneByName = new Map(lanes.map((lane) => [lane.name, lane]));
+  const laneYs = lanes.map((lane) => lane.y).filter(Number.isFinite);
+  const minY = Number.isFinite(genomeTracks?.min_y) ? genomeTracks.min_y : Math.min(...laneYs);
+  const maxY = Number.isFinite(genomeTracks?.max_y) ? genomeTracks.max_y : Math.max(...laneYs);
+  let normalError = 0;
+  let invertedError = 0;
+  let anchorCount = 0;
+
+  (graphData?.nodes || []).forEach((node) => {
+    const lane = (node?.['~labels'] || []).map((label) => laneByName.get(label)).find(Boolean);
+    const coordinateY = getCoordinateCenterY(coordData?.[node?.['~id']]);
+    if (!lane || !Number.isFinite(coordinateY)) {
+      return;
+    }
+
+    normalError += Math.abs(coordinateY - lane.y);
+    invertedError += Math.abs(coordinateY - (minY + maxY - lane.y));
+    anchorCount += 1;
+  });
+
+  const inverted = anchorCount > 0 && invertedError < normalError;
+  return lanes.map((lane) => ({
+    ...lane,
+    modelY: inverted ? minY + maxY - lane.y : lane.y,
+  }));
+};
+
 const getLabelMaxWidth = (renderWidth) => {
   if (!Number.isFinite(renderWidth)) {
     return undefined;
@@ -549,6 +592,7 @@ export default function StandaloneKnowledgeGraph({
   graphData = null,
   coordData = null,
   metadata = null,
+  queryRequest = null,
   containerHeight = '600px',
   defaultLegendVisible = true,
   sx = {},
@@ -577,6 +621,8 @@ export default function StandaloneKnowledgeGraph({
   const [queryDialogOpen, setQueryDialogOpen] = useState(false);
   const [queryResult, setQueryResult] = useState(null);
   const [viewMode, setViewMode] = useState(metadata?.layout?.mode || 'kg_only');
+  const [modeLoading, setModeLoading] = useState(false);
+  const [modeError, setModeError] = useState('');
   const [thumbnailImage, setThumbnailImage] = useState('');
   const [thumbnailViewport, setThumbnailViewport] = useState(null);
   const [viewportState, setViewportState] = useState({
@@ -593,6 +639,7 @@ export default function StandaloneKnowledgeGraph({
   const effectiveMetadata = displayMetadata
     ? { ...displayMetadata, layout: { ...displayMetadata.layout, mode: viewMode } }
     : null;
+  const displayQueryRequest = queryResult?.request || queryRequest;
 
   useEffect(() => {
     if (queryResult?.metadata?.layout?.mode) {
@@ -618,25 +665,16 @@ export default function StandaloneKnowledgeGraph({
     }
 
     const { zoom, panY } = viewportState;
-    const lanes = Array.isArray(genomeRegion.lanes) ? genomeRegion.lanes : [];
-    const regionTopModel = scaleYPosition(genomeRegion.y);
-    const regionBottomModel = scaleYPosition(genomeRegion.y + genomeRegion.height);
-
-    const laneLabels = lanes.map((lane, index) => {
-      const topBoundaryModel = index === 0
-        ? regionTopModel
-        : scaleYPosition((lanes[index - 1].y + lane.y) / 2);
-      const bottomBoundaryModel = index === lanes.length - 1
-        ? regionBottomModel
-        : scaleYPosition((lane.y + lanes[index + 1].y) / 2);
-
-      return {
-        name: lane.name,
-        top: topBoundaryModel * zoom + panY,
-        centerY: scaleYPosition(lane.y) * zoom + panY,
-        height: (bottomBoundaryModel - topBoundaryModel) * zoom,
-      };
-    });
+    const lanes = getGenomeLaneModelYs(
+      genomeRegion,
+      effectiveMetadata?.layout?.genome_tracks,
+      displayGraphData,
+      displayCoordData,
+    );
+    const laneLabels = lanes.map((lane) => ({
+      name: lane.name,
+      centerY: scaleYPosition(lane.modelY) * zoom + panY,
+    }));
 
     return {
       laneLabels,
@@ -659,6 +697,30 @@ export default function StandaloneKnowledgeGraph({
     if (cyRef.current) {
       cyRef.current.zoom(initZoom);
       cyRef.current.center();
+    }
+  };
+
+  const handleModeChange = async (nextMode) => {
+    setModeMenuOpen(false);
+    setModeError('');
+    if (nextMode === viewMode) {
+      return;
+    }
+    if (!displayQueryRequest) {
+      setModeError('Run a graph query before switching layout mode.');
+      return;
+    }
+
+    setModeLoading(true);
+    try {
+      const request = { ...displayQueryRequest, layout_mode: nextMode };
+      const result = await requestGraphViewer(request);
+      setQueryResult(result);
+      setViewMode(result.metadata?.layout?.mode || nextMode);
+    } catch (error) {
+      setModeError(error.message || 'Failed to switch graph layout mode.');
+    } finally {
+      setModeLoading(false);
     }
   };
 
@@ -1096,10 +1158,10 @@ export default function StandaloneKnowledgeGraph({
               </Button>
               {modeMenuOpen && (
                 <Box sx={{ position: 'absolute', top: '58px', right: 0, width: '220px', padding: '6px', background: '#FFFFFF', border: '1px solid #E0E7EB', borderRadius: '8px', boxShadow: '0 5px 15px rgba(48, 69, 82, 0.18)', zIndex: 20 }}>
-                  <Button fullWidth onClick={() => { setViewMode('kg_only'); setModeMenuOpen(false); }} sx={{ justifyContent: 'flex-start', color: '#263238', textTransform: 'none', fontSize: '11px', padding: '8px' }}>
+                  <Button fullWidth disabled={modeLoading || !displayQueryRequest} onClick={() => handleModeChange('kg_only')} sx={{ justifyContent: 'flex-start', color: '#263238', textTransform: 'none', fontSize: '11px', padding: '8px' }}>
                     <span style={{ marginRight: '10px', fontSize: '18px' }}>⌁</span><span><strong>KG mode</strong><br /><small>Generic graph layout</small></span>
                   </Button>
-                  <Button fullWidth disabled={!effectiveMetadata?.layout?.genome_region} onClick={() => { setViewMode('genome_mode'); setModeMenuOpen(false); }} sx={{ justifyContent: 'flex-start', color: '#263238', textTransform: 'none', fontSize: '11px', padding: '8px' }}>
+                  <Button fullWidth disabled={modeLoading || !displayQueryRequest} onClick={() => handleModeChange('genome_mode')} sx={{ justifyContent: 'flex-start', color: '#263238', textTransform: 'none', fontSize: '11px', padding: '8px' }}>
                     <span style={{ marginRight: '10px', fontSize: '18px' }}>▦</span><span><strong>Genome browser mode</strong><br /><small>Genome tracks + KG around</small></span>
                   </Button>
                 </Box>
@@ -1110,6 +1172,11 @@ export default function StandaloneKnowledgeGraph({
         </Box>
       </Box>
       <div style={{ position: 'relative', height: containerHeight, minHeight: '460px', overflow: 'hidden', background: '#F9FAFB' }}>
+      {modeError && (
+        <Alert severity="error" onClose={() => setModeError('')} sx={{ position: 'absolute', top: '12px', right: '16px', zIndex: 8, maxWidth: '420px' }}>
+          {modeError}
+        </Alert>
+      )}
         <div
           ref={containerRef}
           style={{
@@ -1247,7 +1314,7 @@ export default function StandaloneKnowledgeGraph({
           <Box><Typography sx={{ fontSize: '11px', color: '#607887', marginBottom: '7px' }}>Last updated</Typography><Typography sx={{ fontSize: '13px', fontWeight: 700, color: '#263238' }}>{displayMetadata?.last_updated || '—'}</Typography></Box>
         </Box>
       </Box>
-      <GraphViewerQueryDialog open={queryDialogOpen} onClose={() => setQueryDialogOpen(false)} onResult={(payload) => { setQueryResult(payload); setViewMode(payload.metadata?.layout?.mode || 'kg_only'); }} />
+      <GraphViewerQueryDialog open={queryDialogOpen} onClose={() => setQueryDialogOpen(false)} onResult={(payload) => { setQueryResult(payload); setViewMode(payload.metadata?.layout?.mode || 'kg_only'); setModeError(''); }} />
       </div>
     </>
   );

--- a/src/components/StandaloneKnowledgeGraph.test.js
+++ b/src/components/StandaloneKnowledgeGraph.test.js
@@ -21,9 +21,12 @@ describe('getGenomeLaneModelYs', () => {
     ]);
   });
 
-  test('uses group-specific backend lanes when metadata contains multiple groups', () => {
+  test('uses top-level backend lanes once instead of repeating group lanes', () => {
     const lanes = getGenomeLaneModelYs({
-      lanes: [{ name: 'Gene', y: 999 }],
+      lanes: [
+        { name: 'Gene', y: 0 },
+        { name: 'Exon', y: 78 },
+      ],
       groups: [
         {
           genome_assembly: 'GRCh38.p14',
@@ -46,9 +49,7 @@ describe('getGenomeLaneModelYs', () => {
 
     expect(lanes.map(({ name, modelY }) => [name, modelY])).toEqual([
       ['Gene', 0],
-      ['Transcript', 78],
-      ['Gene', 588],
-      ['Transcript', 666],
+      ['Exon', 78],
     ]);
   });
 });

--- a/src/components/StandaloneKnowledgeGraph.test.js
+++ b/src/components/StandaloneKnowledgeGraph.test.js
@@ -1,0 +1,40 @@
+import { getGenomeLaneModelYs } from './StandaloneKnowledgeGraph';
+
+const genomeRegion = {
+  lanes: [
+    { name: 'Gene', y: 0 },
+    { name: 'Transcript', y: 78 },
+    { name: 'other coordinate features', y: 468 },
+  ],
+};
+
+const genomeTracks = { min_y: 0, max_y: 468 };
+const geneGraph = {
+  nodes: [{ '~id': 'gene-1', '~labels': ['Coding_element', 'Gene'] }],
+};
+
+describe('getGenomeLaneModelYs', () => {
+  test('keeps lane coordinates when node and metadata use the same y axis', () => {
+    const lanes = getGenomeLaneModelYs(genomeRegion, genomeTracks, geneGraph, {
+      'gene-1': { start_xy: [0, 12], end_xy: [100, -12] },
+    });
+
+    expect(lanes.map(({ name, modelY }) => [name, modelY])).toEqual([
+      ['Gene', 0],
+      ['Transcript', 78],
+      ['other coordinate features', 468],
+    ]);
+  });
+
+  test('inverts lane coordinates when live node rectangles use the opposite y axis', () => {
+    const lanes = getGenomeLaneModelYs(genomeRegion, genomeTracks, geneGraph, {
+      'gene-1': { start_xy: [0, 480], end_xy: [100, 456] },
+    });
+
+    expect(lanes.map(({ name, modelY }) => [name, modelY])).toEqual([
+      ['Gene', 468],
+      ['Transcript', 390],
+      ['other coordinate features', 0],
+    ]);
+  });
+});

--- a/src/components/StandaloneKnowledgeGraph.test.js
+++ b/src/components/StandaloneKnowledgeGraph.test.js
@@ -9,15 +9,10 @@ const genomeRegion = {
 };
 
 const genomeTracks = { min_y: 0, max_y: 468 };
-const geneGraph = {
-  nodes: [{ '~id': 'gene-1', '~labels': ['Coding_element', 'Gene'] }],
-};
 
 describe('getGenomeLaneModelYs', () => {
-  test('keeps lane coordinates when node and metadata use the same y axis', () => {
-    const lanes = getGenomeLaneModelYs(genomeRegion, genomeTracks, geneGraph, {
-      'gene-1': { start_xy: [0, 12], end_xy: [100, -12] },
-    });
+  test('uses backend lane coordinates without inferring axis direction from nodes', () => {
+    const lanes = getGenomeLaneModelYs(genomeRegion, genomeTracks);
 
     expect(lanes.map(({ name, modelY }) => [name, modelY])).toEqual([
       ['Gene', 0],
@@ -26,15 +21,34 @@ describe('getGenomeLaneModelYs', () => {
     ]);
   });
 
-  test('inverts lane coordinates when live node rectangles use the opposite y axis', () => {
-    const lanes = getGenomeLaneModelYs(genomeRegion, genomeTracks, geneGraph, {
-      'gene-1': { start_xy: [0, 480], end_xy: [100, 456] },
-    });
+  test('uses group-specific backend lanes when metadata contains multiple groups', () => {
+    const lanes = getGenomeLaneModelYs({
+      lanes: [{ name: 'Gene', y: 999 }],
+      groups: [
+        {
+          genome_assembly: 'GRCh38.p14',
+          chr: '7',
+          lanes: [
+            { name: 'Gene', y: 0 },
+            { name: 'Transcript', y: 78 },
+          ],
+        },
+        {
+          genome_assembly: 'GRCh38.p14',
+          chr: '8',
+          lanes: [
+            { name: 'Gene', y: 588 },
+            { name: 'Transcript', y: 666 },
+          ],
+        },
+      ],
+    }, genomeTracks);
 
     expect(lanes.map(({ name, modelY }) => [name, modelY])).toEqual([
-      ['Gene', 468],
-      ['Transcript', 390],
-      ['other coordinate features', 0],
+      ['Gene', 0],
+      ['Transcript', 78],
+      ['Gene', 588],
+      ['Transcript', 666],
     ]);
   });
 });

--- a/src/pages/SampleGraphPage.js
+++ b/src/pages/SampleGraphPage.js
@@ -39,6 +39,7 @@ export default function SampleGraphPage() {
   const [graphData, setGraphData] = useState(null);
   const [coordData, setCoordData] = useState(null);
   const [metadata, setMetadata] = useState(null);
+  const [queryRequest, setQueryRequest] = useState(null);
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -47,10 +48,11 @@ export default function SampleGraphPage() {
     const load = async () => {
       try {
         setError('');
-        const [graph, xy, meta] = await Promise.all([
+        const [graph, xy, meta, request] = await Promise.all([
           loadJson('graph.json'),
           loadFirstAvailableJson(['xy_json.json', 'xy.json']),
           loadJson('metadata.json'),
+          loadJson('request.json'),
         ]);
 
         if (!active) {
@@ -60,6 +62,7 @@ export default function SampleGraphPage() {
         setGraphData(graph);
         setCoordData(xy);
         setMetadata(meta);
+        setQueryRequest(request);
       } catch (err) {
         if (active) {
           setError(err.message || 'Failed to load sample graph data.');
@@ -91,6 +94,7 @@ export default function SampleGraphPage() {
             graphData={graphData}
             coordData={coordData}
             metadata={metadata}
+            queryRequest={queryRequest}
             containerHeight="calc(100vh - 315px)"
             defaultLegendVisible={true}
           />


### PR DESCRIPTION
## Summary
- parse PostgreSQL graph-viewer request objects without converting them into invalid Cypher text
- keep structured PostgreSQL request fields intact through query submission
- make KG mode and genome-browser mode switching re-query the backend with the selected layout mode
- align genome-track lane rendering with backend-provided lane metadata
- preserve mode state across the sample graph query flow
- add focused regression tests for request parsing and layout-mode switching

## Backend compatibility
This frontend update targets the current GKB graph-viewer backend contract. Future graph-viewer development uses the GKB implementation as the baseline; the PanKgraph backend is not the source for this change.

## Validation
- `CI=true npm test -- --runInBand src/components/GraphViewerQueryDialog.test.js src/components/StandaloneKnowledgeGraph.test.js` (2 suites, 4 tests passed)
- `npm run build` (completed successfully; existing repository ESLint warnings remain)
- `git diff --check`

Ready for owner review and merge into `xuteng/react`.