### PR TITLE
Fix multi-label genome track rendering

### DIFF
--- a/src/components/StandaloneKnowledgeGraph.js
+++ b/src/components/StandaloneKnowledgeGraph.js
@@ -229,11 +229,41 @@ const PANK_TYPE_MAP = {
   UTR_segments: 'region',
 };
 
+const CANONICAL_NODE_LABEL_PRIORITY = [
+  'Gene',
+  'Transcript',
+  'TSS_segment',
+  'Exon',
+  'CDS_segments',
+  'UTR_segments',
+  'Protein',
+  'GO_term',
+];
+
+const GENERIC_NODE_LABELS = new Set(['ontology', 'coding_element', 'coding_elements']);
+
 const normalizeNodeType = (label) => PANK_TYPE_MAP[label] || label;
 
+export const getCanonicalNodeLabel = (node) => {
+  const labels = Array.isArray(node?.['~labels'])
+    ? node['~labels'].filter(Boolean).map(String)
+    : (node?.['~labels'] ? [String(node['~labels'])] : []);
+  const labelsByLower = new Map(labels.map((label) => [label.toLowerCase(), label]));
+  const canonicalLabel = CANONICAL_NODE_LABEL_PRIORITY.find(
+    (label) => labelsByLower.has(label.toLowerCase()),
+  );
+
+  return canonicalLabel
+    || labels.find((label) => !GENERIC_NODE_LABELS.has(label.toLowerCase()))
+    || labels[0]
+    || 'coding_elements';
+};
+
 const getNodeType = (node) => {
-  const labels = node?.['~labels'] || [];
-  return labels
+  const labels = Array.isArray(node?.['~labels']) ? node['~labels'] : [];
+  const canonicalLabel = getCanonicalNodeLabel(node);
+  const orderedLabels = [canonicalLabel, ...labels.filter((label) => label !== canonicalLabel)];
+  return orderedLabels
     .map(normalizeNodeType)
     .find((label) => graphInfocard.nodes?.[label]?.info_panel || nodeColors[label]) || 'coding_elements';
 };

--- a/src/components/StandaloneKnowledgeGraph.test.js
+++ b/src/components/StandaloneKnowledgeGraph.test.js
@@ -1,4 +1,7 @@
-import { getGenomeLaneModelYs } from './StandaloneKnowledgeGraph';
+import {
+  getCanonicalNodeLabel,
+  getGenomeLaneModelYs,
+} from './StandaloneKnowledgeGraph';
 
 const genomeRegion = {
   lanes: [
@@ -51,5 +54,20 @@ describe('getGenomeLaneModelYs', () => {
       ['Gene', 0],
       ['Exon', 78],
     ]);
+  });
+});
+
+describe('getCanonicalNodeLabel', () => {
+  test('uses the complete label set instead of depending on Neo4j label order', () => {
+    expect(getCanonicalNodeLabel({ '~labels': ['Coding_element', 'Gene'] })).toBe('Gene');
+    expect(getCanonicalNodeLabel({ '~labels': ['Gene', 'Coding_element'] })).toBe('Gene');
+    expect(
+      getCanonicalNodeLabel({ '~labels': ['Ontology', 'Transcript', 'Coding_element'] }),
+    ).toBe('Transcript');
+  });
+
+  test('preserves unknown domain labels when no canonical label exists', () => {
+    expect(getCanonicalNodeLabel({ '~labels': ['Coding_element', 'Custom_feature'] }))
+      .toBe('Custom_feature');
   });
 });


### PR DESCRIPTION
## Summary
- resolve node type from the complete Neo4j `~labels` set with deterministic biological-entity priority
- handle labels such as `["Coding_element", "Gene"]` independently of label order
- preserve unknown domain labels when no known entity label is present
- keep frontend node styling aligned with backend genome-lane classification

## Root cause
Neo4j nodes can carry both container and entity labels, and label order is not a stable contract. The reported CFTR query returns Gene nodes as `["Coding_element", "Gene"]`. Entity classification must inspect the complete label set rather than treating one label as authoritative.

## Backend dependency
Graph_viewer `GKB` is already updated at commit `449756b`. It also places multi-chromosome Gene results in one active Gene lane, uses global Gene-length scaling, and removes the old large vertical separation. The live graph API must deploy that GKB commit for the layout change to appear.

## Validation
- `CI=true npm test -- --runInBand src/components/GraphViewerQueryDialog.test.js src/components/StandaloneKnowledgeGraph.test.js` (2 suites, 6 tests passed)
- `npm run build` (successful; existing repository warnings remain)
- backend tests: 5 passed
- live CFTR response replay: one Gene lane, all Gene nodes at y=0, no rectangle overlap
